### PR TITLE
Push Docker image via CDP

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,0 +1,10 @@
+build_steps:
+    - desc: 'Install required build software'
+      cmd: 'apt-get install -y apt-transport-https ca-certificates curl'
+    - desc: 'Install Docker'
+      cmd: 'curl -sSL https://get.docker.com/ | sh'
+    - desc: 'Build'
+      cmd: |
+        image=registry-write.opensource.zalan.do/teapot/aws-credentials-service:${CDP_BUILD_VERSION}
+        docker build -t $image .
+        docker push $image


### PR DESCRIPTION
Build and push Docker image to OSS registry via CDP (delivery.yaml). This only works for master branch.